### PR TITLE
fix: replace Obytes boilerplate with MapYourHealth branding

### DIFF
--- a/src/translations/ar.json
+++ b/src/translations/ar.json
@@ -1,6 +1,6 @@
 {
   "onboarding": {
-    "message": "مرحبا بكم في موقع تطبيق obytes"
+    "message": "مرحبا بكم في MapYourHealth"
   },
   "settings": {
     "about": "حول التطبيق ",
@@ -29,5 +29,5 @@
     "version": "إصدار",
     "website": "موقع الكتروني"
   },
-  "welcome": "test arabic"
+  "welcome": "مرحبا بكم في MapYourHealth"
 }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -46,7 +46,7 @@
     "zipCode": "Zip Code"
   },
   "onboarding": {
-    "message": "Welcome to obytes app site"
+    "message": "Welcome to MapYourHealth"
   },
   "settings": {
     "about": "About",
@@ -75,7 +75,7 @@
     "version": "Version",
     "website": "Website"
   },
-  "welcome": "Welcome to obytes app site",
+  "welcome": "Welcome to MapYourHealth",
   "confirm": {
     "loading": "Confirming your subscription...",
     "success": "Thank you for confirming your subscription!",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -43,7 +43,7 @@
     }
   },
   "onboarding": {
-    "message": "Welcome to obytes app site"
+    "message": "Bienvenue sur MapYourHealth"
   },
   "settings": {
     "about": "About",
@@ -72,7 +72,7 @@
     "version": "Version",
     "website": "Website"
   },
-  "welcome": "Welcome to obytes app site",
+  "welcome": "Bienvenue sur MapYourHealth",
   "appName": "MapYourHealth",
   "footer": {
     "copyright": "Copyright"


### PR DESCRIPTION
## Summary
- Replace "Welcome to obytes app site" with "Welcome to MapYourHealth" in all translation files
- Update English, French, and Arabic translations

## Changes
| File | Before | After |
|------|--------|-------|
| en.json | "Welcome to obytes app site" | "Welcome to MapYourHealth" |
| fr.json | "Welcome to obytes app site" | "Bienvenue sur MapYourHealth" |
| ar.json | "مرحبا بكم في موقع تطبيق obytes" | "مرحبا بكم في MapYourHealth" |

## Note
Pre-existing translation key sync issues exist between language files (ar.json is missing several keys). This is a separate issue that should be addressed in a future PR.

## Test plan
- [ ] Verify welcome/onboarding messages display correctly in English
- [ ] Verify welcome/onboarding messages display correctly in French
- [ ] Verify welcome/onboarding messages display correctly in Arabic

🤖 Generated with [Claude Code](https://claude.com/claude-code)