### PR TITLE
fix: update landing page content per Rayane's feedback (#181)

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1,25 +1,31 @@
 {
   "appName": "MapYourHealth",
+  "confirm": {
+    "error": "There was an error confirming your subscription. Please try again or contact support.",
+    "invalidCode": "Invalid confirmation code. Please check your email for the correct link.",
+    "loading": "Confirming your subscription...",
+    "success": "Thank you for confirming your subscription!"
+  },
   "footer": {
     "copyright": "Copyright"
   },
   "home": {
-    "enterZipCode": "Please enter your zipCode",
     "CTA1": "It is responsible for one in six deaths worldwide, causing cancer, heart and respiratory diseases, multiple chemical sensitivity and more chronic illnesses.\n\n\n Protect your health now. Sign up to ",
     "CTA2": " and learn about all health hazards in your surroundings.",
     "benefits": {
-      "title1": "Expose Hidden Toxic Pollutants",
       "content1": "Track in real time the presence of Forever Chemicals (PFAS), radon, endocrine disruptors, pathogens, sulfur dioxide (SO2), volatile organic compounds (VOCs), heavy metals, ozone, particulate matter, and more.",
+      "content2": "Assess the quality of water treatment, healthcare, fire department, energy supply, law enforcement and environment protection in your city.",
+      "content3": "Access the latest scientific recommendations, affordable technologies and services combating dangerous pollutants.",
+      "content4": "Get informed about the health risks of living in other cities when planning travels or relocation.",
+      "title1": "Expose Hidden Toxic Pollutants",
       "title2": "Monitor Essential Public Services",
-      "content2": "Assess the quality of water treatment, healthcare, fire services, energy supply, law enforcement, and environmental protection in your city.",
       "title3": "Self-Defense Against Pollutants",
-      "content3": "Access the latest scientific recommendations in environmental health, affordable protective technologies, and services to combat dangerous pollutants.",
-      "title4": "Plan Travels and Relocation",
-      "content4": "Get informed about the health risks of living in other cities when planning travels or relocation."
+      "title4": "Plan Travels and Relocation"
     },
     "benefitsTitle": "More benefits to ",
     "description": "It is contaminating every breath you take, every glass of water you drink, and every meal you eat, causing multiple chemical sensitivity, cancer, heart disease, poisoning, and more. It is an invisible and deadly threat to you and your family.",
     "enterEmail": "Enter your email",
+    "enterZipCode": "Please enter your zipCode",
     "errorMessage": "Whoops, enter a correct email.",
     "faq": {
       "answer1": "MapYourHealth is an interactive map monitoring all health hazards in your immediate environment and beyond. This unique platform visually represents research studies, public health records, and investigative reporting pertaining to environmental health.",
@@ -33,7 +39,7 @@
       "question3": "How do I use MapYourHealth?",
       "question4": "Is MapYourHealth available everywhere?",
       "question5": "Is MapYourHealth free?",
-      "question6": "Submit a signal on environmental hazards"
+      "question6": "Submit a tip on environmental hazards"
     },
     "faqTitle": "Frequently Asked Questions",
     "invalidEmail": "Please enter a valid email address.",
@@ -75,11 +81,5 @@
     "version": "Version",
     "website": "Website"
   },
-  "welcome": "Welcome to obytes app site",
-  "confirm": {
-    "loading": "Confirming your subscription...",
-    "success": "Thank you for confirming your subscription!",
-    "error": "There was an error confirming your subscription. Please try again or contact support.",
-    "invalidCode": "Invalid confirmation code. Please check your email for the correct link."
-  }
+  "welcome": "Welcome to obytes app site"
 }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -13,24 +13,24 @@
     "CTA1": "It is responsible for one in six deaths worldwide, causing cancer, heart and respiratory diseases, multiple chemical sensitivity and more chronic illnesses.\n\n\n Protect your health now. Sign up to ",
     "CTA2": " and learn about all health hazards in your surroundings.",
     "benefits": {
-      "content1": "Track in real time the presence of Forever Chemicals (PFAS), radon, endocrine disruptors, pathogens, sulfur dioxide (SO2), volatile organic compounds (VOCs), heavy metals, ozone, particulate matter, and more.",
+      "content1": "Track in real time the presence of Forever Chemicals (PFAS), Radon, endocrine disruptors, Pathogens, Sulfur Dioxide (SO2), Volatile Organic Compounds (VOCs), Heavy Metals, Ozone, Particulate Matter and more.",
       "content2": "Assess the quality of water treatment, healthcare, fire department, energy supply, law enforcement and environment protection in your city.",
       "content3": "Access the latest scientific recommendations, affordable technologies and services combating dangerous pollutants.",
-      "content4": "Get informed about the health risks of living in other cities when planning travels or relocation.",
+      "content4": "Get informed on the health risks of living in other cities when planning travels or relocation.",
       "title1": "Expose Hidden Toxic Pollutants",
       "title2": "Monitor Essential Public Services",
       "title3": "Self-Defense Against Pollutants",
       "title4": "Plan Travels and Relocation"
     },
-    "benefitsTitle": "More benefits to ",
-    "description": "It is contaminating every breath you take, every glass of water you drink, and every meal you eat, causing multiple chemical sensitivity, cancer, heart disease, poisoning, and more. It is an invisible and deadly threat to you and your family.",
+    "benefitsTitle": "More benefits to Sign Up",
+    "description": "It is responsible for one in six deaths worldwide, causing cancer, heart and respiratory diseases, multiple chemical sensitivity and more chronic illnesses.",
     "enterEmail": "Enter your email",
     "enterZipCode": "Please enter your zipCode",
     "errorMessage": "Whoops, enter a correct email.",
     "faq": {
-      "answer1": "MapYourHealth is an interactive map monitoring all health hazards in your immediate environment and beyond. This unique platform visually represents research studies, public health records, and investigative reporting pertaining to environmental health.",
-      "answer2": "Environmental pollutants are endangering the health of everyone. Depending on where you are, they can lead to a range of serious short-term and long-term problems, including Chemical Sensitivity (CS), respiratory issues, cardiovascular diseases, cancers, developmental disorders, and other chronic illnesses.",
-      "answer3": "MapYourHealth offers you the platform to monitor environmental threats to your health in order to safely make lifestyle choices, prospect for new living spaces, plan travels, and stay updated on the latest recommendations and technologies countering environmental pollutants.",
+      "answer1": "MapYourHealth is an interactive map monitoring all health hazards in your immediate environment and beyond.\nThis unique platform visually represents research studies, public health records and investigative reporting pertaining to environmental health.",
+      "answer2": "Environmental pollutants are endangering the health of everyone. Depending on where you are, they can lead to a range of serious short-term and long-term problems, including Chemical Sensitivity (CS), respiratory issues, cardiovascular diseases, cancers, developmental disorders and other chronic illnesses.",
+      "answer3": "MapYourHealth offers you the platform to monitor environmental threats to your health in order to safely make lifestyle choices, prospect for new living spaces, plan travels and stay updated on the latest recommendations and technologies countering environmental pollutants.",
       "answer4": "MapYourHealth might not yet be available in your location. Sign up to receive an automatic email alert as soon as MapYourHealth becomes available in your city.",
       "answer5": "MapYourHealth is free. But good health is worth more than gold.",
       "answer6": "Get in touch with MapYourHealth and let us know about any source of toxic pollution plaguing your hometown. Emails sent to contact@mapyourhealth.info will be treated in all confidentiality.",
@@ -52,7 +52,7 @@
     "zipCode": "Zip Code"
   },
   "onboarding": {
-    "message": "Welcome to obytes app site"
+    "message": "Welcome to MapYourHealth"
   },
   "settings": {
     "about": "About",
@@ -81,5 +81,5 @@
     "version": "Version",
     "website": "Website"
   },
-  "welcome": "Welcome to obytes app site"
+  "welcome": "Welcome to MapYourHealth"
 }

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -1,46 +1,55 @@
 {
+  "appName": "MapYourHealth",
+  "confirm": {
+    "error": "Une erreur s'est produite lors de la confirmation de votre abonnement. Veuillez réessayer ou contacter le support.",
+    "invalidCode": "Code de confirmation invalide. Veuillez vérifier votre email pour le bon lien.",
+    "loading": "Confirmation de votre abonnement en cours...",
+    "success": "Merci d'avoir confirmé votre abonnement !"
+  },
+  "footer": {
+    "copyright": "Copyright"
+  },
   "home": {
-    "title": "La pollution toxique menace votre santé",
-    "subtitle": "Elle contamine chaque respiration que vous prenez, chaque verre d'eau que vous buvez et chaque repas que vous mangez, causant une sensibilité chimique, le cancer, des maladies cardiaques, des empoisonnements et plus encore. \n\n C'est une menace invisible et mortelle pour vous et votre famille.\n\n Protégez votre santé maintenant. Inscrivez-vous à MapYourHealth et apprenez tous les dangers pour la santé dans votre environnement.",
-    "enterEmail": "Entrez votre email",
-    "errorMessage": "Oups, entrez un email correct.",
-    "selectCountry": "Sélectionnez votre pays",
-    "signUp": "s'inscrire",
-    "enterZipCode": "Veuillez saisir votre code postal",
-    "success": "Merci de vous être inscrit",
-    "successAlreadyRegistered": "Cet email a déjà été enregistré",
-    "zipCode": "Code postal",
-    "invalidEmail": "Veuillez entrer une adresse e-mail valide.",
-    "description": "Il contamine chaque respiration que vous prenez, chaque verre d'eau que vous buvez et chaque repas que vous mangez, causant une sensibilité chimique, le cancer, des maladies cardiaques, des empoisonnements et plus encore.",
-    "callToAction": "Protégez votre santé maintenant. Inscrivez-vous à MapYourHealth et apprenez tout sur les dangers pour la santé dans votre environnement.",
-    "benefitsTitle": "Plus d'avantages à ",
     "CTA1": "Elle est responsable d'un décès sur six dans le monde, causant des cancers, des maladies cardiaques et respiratoires, l'hypersensibilité chimique et de nombreuses autres maladies chroniques. \n\n\n Protégez votre santé dès maintenant. Inscrivez-vous à ",
     "CTA2": " et identifiez toutes les menaces environnementales dans votre localité.",
     "benefits": {
-      "title1": "Exposez les polluants toxiques cachés",
       "content1": "Suivez en temps réel la présence de produits chimiques permanents (PFAS), de radon, de perturbateurs endocriniens, d'agents pathogènes, de dioxyde de soufre (SO2), de composés organiques volatils (COV), de métaux lourds, d'ozone, de particules fines et plus encore.",
-      "title2": "Contrôlez la qualité des services publics essentiels",
       "content2": "Évaluez la qualité du traitement de l'eau, des soins de santé, des services d'incendie, de l'approvisionnement en énergie, de l'application de la loi et de la protection de l'environnement dans votre ville.",
-      "title3": "Autodéfense contre les polluants",
       "content3": "Accédez aux dernières recommandations scientifiques en santé environnementale, à des technologies de protection abordables et à des services de lutte contre les polluants dangereux.",
-      "title4": "Planifiez vos voyages et votre déménagement",
-      "content4": "Soyez informé des risques pour la santé liés à la vie dans d'autres villes lorsque vous planifiez des voyages ou un déménagement."
+      "content4": "Soyez informé des risques pour la santé liés à la vie dans d'autres villes lorsque vous planifiez des voyages ou un déménagement.",
+      "title1": "Exposez les polluants toxiques cachés",
+      "title2": "Contrôlez la qualité des services publics essentiels",
+      "title3": "Autodéfense contre les polluants",
+      "title4": "Planifiez vos voyages et votre déménagement"
+    },
+    "benefitsTitle": "Plus d'avantages à ",
+    "description": "Elle est responsable d'un décès sur six dans le monde, causant des cancers, des maladies cardiaques et respiratoires, l'hypersensibilité chimique et de nombreuses autres maladies chroniques.",
+    "enterEmail": "Entrez votre email",
+    "enterZipCode": "Veuillez saisir votre code postal",
+    "errorMessage": "Oups, entrez un email correct.",
+    "faq": {
+      "answer1": "MapYourHealth est une carte interactive qui vous informe de tous les dangers sanitaires dans votre environnement immédiat et au-delà. Cette plateforme unique représente visuellement des études scientifiques, des rapports de la santé publique et des articles d'enquête journalistiques relatifs à la santé environnementale.",
+      "answer2": "Les polluants environnementaux mettent en danger la santé de tous. Selon l'endroit où vous vous trouvez, ils peuvent entraîner toute une série de problèmes graves à court et long terme, notamment l'hypersensibilité chimique, des problèmes respiratoires, des maladies cardiovasculaires, des cancers, des troubles du développement et d'autres maladies chroniques.",
+      "answer3": "MapYourHealth vous permet de faire des choix informés et sécuritaires, de rechercher de nouveaux espaces de vie, de planifier des voyages et de rester informé des dernières recommandations et technologies pour rester protégé des menaces environnementales.",
+      "answer4": "MapYourHealth n'est peut-être pas encore disponible dans votre région. Inscrivez-vous pour recevoir une alerte automatique par courriel dès que MapYourHealth sera disponible dans votre ville.",
+      "answer5": "MapYourHealth est gratuit. Mais une bonne santé vaut plus que de l'or.",
+      "answer6": "Contactez MapYourHealth et signalez toute source de pollution toxique qui affecte votre ville. Les courriels envoyés à contact@mapyourhealth.info seront traités en toute confidentialité.",
+      "question1": "Qu'est-ce que MapYourHealth ?",
+      "question2": "Pourquoi devrais-je me soucier des polluants environnementaux ?",
+      "question3": "Comment utiliser MapYourHealth ?",
+      "question4": "MapYourHealth est-il disponible partout ?",
+      "question5": "MapYourHealth est-il gratuit ?",
+      "question6": "Signalez la présence de dangers environnementaux"
     },
     "faqTitle": "Questions Fréquemment Posées",
-    "faq": {
-      "question1": "Qu'est-ce que MapYourHealth ?",
-      "answer1": "MapYourHealth est une carte interactive qui vous informe de tous les dangers sanitaires dans votre environnement immédiat et au-delà. Cette plateforme unique représente visuellement des études scientifiques, des rapports de la santé publique et des articles d'enquête journalistiques relatifs à la santé environnementale.",
-      "question2": "Pourquoi devrais-je me soucier des polluants environnementaux ?",
-      "answer2": "Les polluants environnementaux mettent en danger la santé de tous. Selon l'endroit où vous vous trouvez, ils peuvent entraîner toute une série de problèmes graves à court et long terme, notamment l'hypersensibilité chimique, des problèmes respiratoires, des maladies cardiovasculaires, des cancers, des troubles du développement et d'autres maladies chroniques.",
-      "question3": "Comment utiliser MapYourHealth ?",
-      "answer3": "MapYourHealth vous permet de faire des choix informés et sécuritaires, de rechercher de nouveaux espaces de vie, de planifier des voyages et de rester informé des dernières recommandations et technologies pour rester protégé des menaces environnementales.",
-      "question4": "MapYourHealth est-il disponible partout ?",
-      "answer4": "MapYourHealth n'est peut-être pas encore disponible dans votre région. Inscrivez-vous pour recevoir une alerte automatique par courriel dès que MapYourHealth sera disponible dans votre ville.",
-      "question5": "MapYourHealth est-il gratuit ?",
-      "answer5": "MapYourHealth est gratuit. Mais une bonne santé vaut plus que de l'or.",
-      "question6": "Signalez la présence de dangers environnementaux",
-      "answer6": "Contactez MapYourHealth et signalez toute source de pollution toxique qui affecte votre ville. Les courriels envoyés à contact@mapyourhealth.info seront traités en toute confidentialité."
-    }
+    "invalidEmail": "Veuillez entrer une adresse e-mail valide.",
+    "selectCountry": "Sélectionnez votre pays",
+    "signUp": "s'inscrire",
+    "subtitle": "Elle est responsable d'un décès sur six dans le monde, causant des cancers, des maladies cardiaques et respiratoires, l'hypersensibilité chimique et de nombreuses autres maladies chroniques.\n\n\n Protégez votre santé dès maintenant. Inscrivez-vous à MapYourHealth et identifiez toutes les menaces environnementales dans votre localité.",
+    "success": "Merci de vous être inscrit",
+    "successAlreadyRegistered": "Cet email a déjà été enregistré",
+    "title": "La pollution environnementale est votre nouveau voisin",
+    "zipCode": "Code postal"
   },
   "onboarding": {
     "message": "Welcome to obytes app site"
@@ -72,15 +81,5 @@
     "version": "Version",
     "website": "Website"
   },
-  "welcome": "Welcome to obytes app site",
-  "appName": "MapYourHealth",
-  "footer": {
-    "copyright": "Copyright"
-  },
-  "confirm": {
-    "loading": "Confirmation de votre abonnement en cours...",
-    "success": "Merci d'avoir confirmé votre abonnement !",
-    "error": "Une erreur s'est produite lors de la confirmation de votre abonnement. Veuillez réessayer ou contacter le support.",
-    "invalidCode": "Code de confirmation invalide. Veuillez vérifier votre email pour le bon lien."
-  }
+  "welcome": "Welcome to obytes app site"
 }

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -22,7 +22,7 @@
       "title3": "Autodéfense contre les polluants",
       "title4": "Planifiez vos voyages et votre déménagement"
     },
-    "benefitsTitle": "Plus d'avantages à ",
+    "benefitsTitle": "Plus d'avantages à s'inscrire",
     "description": "Elle est responsable d'un décès sur six dans le monde, causant des cancers, des maladies cardiaques et respiratoires, l'hypersensibilité chimique et de nombreuses autres maladies chroniques.",
     "enterEmail": "Entrez votre email",
     "enterZipCode": "Veuillez saisir votre code postal",
@@ -52,7 +52,7 @@
     "zipCode": "Code postal"
   },
   "onboarding": {
-    "message": "Welcome to obytes app site"
+    "message": "Bienvenue sur MapYourHealth"
   },
   "settings": {
     "about": "About",
@@ -81,5 +81,5 @@
     "version": "Version",
     "website": "Website"
   },
-  "welcome": "Welcome to obytes app site"
+  "welcome": "Bienvenue sur MapYourHealth"
 }


### PR DESCRIPTION
## Summary
Aligns all landing page content with Rayane's Google Doc ("Content Landing Page", shared April 1, 2026).

### English changes:
- **Headline**: No change (already matches)
- **Benefits title**: "More benefits to" → "More benefits to Sign Up"
- **Benefit 1**: Capitalize contaminant names (Radon, Pathogens, Heavy Metals, Ozone, Particulate Matter, etc.)
- **Benefit 2**: "fire services" → "fire department", "environmental protection" → "environment protection"
- **Benefit 3**: Align wording with Rayane's version
- **Benefit 4**: "about the health risks" → "on the health risks"
- **Description**: Replace old "contaminating every breath" copy with "one in six deaths" version
- **FAQ Q1**: Add line break between sentences per doc
- **FAQ Q2, Q3**: Remove Oxford commas to match Rayane's copy
- **FAQ Q6**: "Submit a signal" → "Submit a tip"
- **Boilerplate**: Fix remaining "obytes" references → "MapYourHealth"

### French changes:
- **Title**: "La pollution toxique menace votre santé" → "La pollution environnementale est votre nouveau voisin"
- **Subtitle**: Updated to Rayane's April 2026 version
- **Description**: Updated to match new copy
- **Benefits title**: "Plus d'avantages à" → "Plus d'avantages à s'inscrire"
- **Removed**: Unused `callToAction` key (was causing i18n lint mismatch)
- **Boilerplate**: Fix "obytes" references → "Bienvenue sur MapYourHealth"

## Related
- epiphanyapps/mapyourhealth#181
- Content source: [Google Doc](https://docs.google.com/document/d/16MaRhN08SOZ8Tvfhi4SKJFTxZoGtY1RJILbvZ3XnTdI/edit)

## Test plan
- [x] i18n lint passes (identical keys across en/fr)
- [x] Type check passes
- [x] Prettier passes
- [ ] Visual check on staging after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)